### PR TITLE
Adding Vim plugin for Tact (tact.vim) to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ A curated list of resources designed to help you learn and program in Tact.
 ### Developer Tools
 
 - [Visual Studio Code Extension for Tact](https://marketplace.visualstudio.com/items?itemName=ton-community.tact-vscode)
+- [Vim 8+ plugin for Tact](https://github.com/novusnota/tact.vim)
 
 ### Boilerplates
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ A curated list of resources designed to help you learn and program in Tact.
 ### Developer Tools
 
 - [Visual Studio Code Extension for Tact](https://marketplace.visualstudio.com/items?itemName=ton-community.tact-vscode)
-- [Vim 8+ plugin for Tact](https://github.com/novusnota/tact.vim)
+- [Vim 8+ plugin for Tact](https://github.com/tact-lang/tact.vim)
 
 ### Boilerplates
 


### PR DESCRIPTION
Adding [tact.vim](https://github.com/tact-lang/tact.vim) to Developer Tools section. It offers a comprehensive support of the Tact language in Vim 8+, including: syntax highlighting, grammar support, auto-completion and basic linting capabilities, as well as formatting and many small quality of life features ⚡